### PR TITLE
Use dedicated lane for creating a build for Appium that handles build…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,10 +142,7 @@ jobs:
             git clone git@github.com:freeletics/fl-application-ios.git
             cd fl-application-ios
             bundle install
-            bundle exec fastlane create_adhoc_build
-            bundle exec pod install
-            pwd
-            ls
+            bundle exec fastlane create_build_for_appium
       - persist_to_workspace:
           root: fl-application-ios/
           paths:


### PR DESCRIPTION
- Use dedicated lane for creating a build for Appium that handles build numbers slightly differently
- also remove unnecessary commands (speeded up the build 🙂)
